### PR TITLE
Fixes duplicate class errors

### DIFF
--- a/dx/src/com/android/dx/command/dexer/Main.java
+++ b/dx/src/com/android/dx/command/dexer/Main.java
@@ -483,7 +483,11 @@ public class Main {
             ClassDefItem clazz =
                 CfTranslator.translate(name, bytes, args.cfOptions, args.dexOptions);
             synchronized (outputDex) {
-                outputDex.add(clazz);
+				try{
+					outputDex.add(clazz);
+				} catch(IllegalArgumentException e){
+					//Ignored
+				}
             }
             return true;
         } catch (ParseException ex) {


### PR DESCRIPTION
Fixed the "already added" bug by simply ignoring duplicate classes that are added. This may not be a "perfect" solution, but it's massively better than the current state, which is "it won't build at all". This is in line with how java works in general anyways, so it shouldn't be a huge surprise if someone comes across this behavior accidentally. Since this bug has been in the tools for 3 revisions, it's due to be fixed now, one way or another.

This addresses bugs 228 (4 stars), 20398 (36 stars), 20956 (48 stars).
