### PR TITLE
Some buffers are not cleared when running with "--multi-dex" option enabled

### DIFF
--- a/dx/src/com/android/dx/command/dexer/Main.java
+++ b/dx/src/com/android/dx/command/dexer/Main.java
@@ -260,6 +260,9 @@ public class Main {
         // empty the list, so that  tools that load dx and keep it around
         // for multiple runs don't reuse older buffers.
         libraryDexBuffers.clear();
+        dexOutputArrays.clear();
+        dexOutputFutures.clear();
+        addToDexFutures.clear();
 
         args = arguments;
         args.makeOptionsObjects();


### PR DESCRIPTION
When using dx.jar as a library and starting multiple separate transformations via the "run(..) method and the "--multi-dex" option enabled, classes.dex files generated for previous transformation are not removed from output buffers and end up in the output list for the current transformation. This leads to a continuously growing amount of classesN.dex files being written to new transformations.

This is only the case for the multi-dex case (runMultiDex()). For the monoDex case, the buffers used are cleared properly:

260:  // empty the list, so that  tools that load dx and keep it around
261:  // for multiple runs don't reuse older buffers.
262:  libraryDexBuffers.clear();

In the runMultiDex() case, the output buffers used are

201:  private static List<Future<byte[]>> dexOutputFutures = new ArrayList<Future<byte[]>>();
226:  private static List<byte[]> dexOutputArrays = new ArrayList<byte[]>();

which are never cleared.

This patch clear the buffers used in the multiDex case accordingly to the buffers used in the monoDex case.
